### PR TITLE
:sparkles: feat: support for react file extensions

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,11 +1,40 @@
 #! /usr/bin/env node
 
 const inquirer = require('inquirer');
+const os = require("os");
+const fs = require("fs");
 
 const questions = require('./data/questions');
 const spiltPath = require('./utils/splitPath');
 const createComponent = require('./lib/createComponent');
 
+const cwd = process.cwd();
+const configFilePath = `${cwd}/.nextrate/config.json`;
+
 inquirer.prompt(questions).then(async (answers) => {
   createComponent(answers.component, spiltPath(answers.path), answers.path)
+
+  if (answers.config === 'y') {
+    if (!fs.existsSync("tsconfig.json")) {
+      fs.mkdirSync(".nextrate");
+      fs.writeFileSync(configFilePath, JSON.stringify({ reactExtension: "jsx" }));
+    }
+    else {
+      fs.mkdirSync(".nextrate");
+      fs.writeFileSync(configFilePath, JSON.stringify({ reactExtension: "tsx" }));
+    }
+  }
+  else if (answers.config === 'n') {
+    if (!fs.existsSync("tsconfig.json")) {
+      fs.mkdirSync(".nextrate");
+      fs.writeFileSync(configFilePath, JSON.stringify({ reactExtension: "js" }));
+    }
+    else {
+      fs.mkdirSync(".nextrate");
+      fs.writeFileSync(configFilePath, JSON.stringify({ reactExtension: "ts" }));
+    }
+  }
+  else {
+    return
+  }
 });

--- a/bin/data/questions.js
+++ b/bin/data/questions.js
@@ -1,16 +1,44 @@
-// The initial questions which are been asked to the user when he runs the `nextrate` command
+const fs = require("fs");
 
-const questions = [
-  {
-    type: 'text',
-    name: 'component',
-    message: 'Enter the component name'
-  },
-  {
-    type: 'text',
-    name: 'path',
-    message: 'Enter the folder path where you want to generate the component'
-  }
-]
+const cwd = process.cwd();
+const configFilePath = `${cwd}/.nextrate/config.json`;
+
+var questions;
+
+if (fs.existsSync(configFilePath)) {
+  questions = [
+    {
+      type: 'text',
+      name: 'component',
+      message: 'Enter the component name'
+    },
+    {
+      type: 'text',
+      name: 'path',
+      message: 'Enter the folder path where you want to generate the component'
+    }
+  ]
+}
+
+else {
+  questions = [
+    {
+      type: 'text',
+      name: 'component',
+      message: 'Enter the component name'
+    },
+    {
+      type: 'text',
+      name: 'path',
+      message: 'Enter the folder path where you want to generate the component'
+    },
+    {
+      type: 'input',
+      name: 'config',
+      message: '✨ config: Do you want to use the .jsx and .tsx file format for the component? (y/n)',
+      choices: ['y', 'n'],
+    }
+  ]
+}
 
 module.exports = questions

--- a/bin/lib/createComponent.js
+++ b/bin/lib/createComponent.js
@@ -1,9 +1,13 @@
 const fs = require('fs');
 const listr = require('listr');
 const chalk = require('chalk');
-const shelljs = require('shelljs')
+const shelljs = require('shelljs');
+const objectPath = require('object-path');
 
 const createFile = require('../utils/createFile');
+
+const cwd = process.cwd();
+const configFilePath = `${cwd}/.nextrate/config.json`;
 
 function createComponent(name, type, path) {
   const tasks = new listr([
@@ -14,29 +18,55 @@ function createComponent(name, type, path) {
         // Checking where there is a tsconfig.json file in the current directory
 
         if (!fs.existsSync('tsconfig.json')) {
-          extension = 'js';
-          if (fs.existsSync(path)) {
-            createFile(path, name, type, extension);
+          if (!fs.existsSync(configFilePath)) {
+            extension = 'js';
+            if (fs.existsSync(path)) {
+              createFile(path, name, type, extension);
+            }
+            else {
+              console.log(chalk.red(`🦄 Directory not found! Creating the directory...`));
+              shelljs.mkdir('-p', path);
+              console.log(chalk.green(`🦄 Directory created! Adding the component...`))
+              createFile(path, name, type, extension);
+            }
           }
           else {
-            console.log(chalk.red(`🦄 Directory not found! Creating the directory...`));
-            shelljs.mkdir('-p', path);
-            console.log(chalk.green(`🦄 Directory created! Adding the component...`))
-            createFile(path, name, type, extension);
+            extension = objectPath.get(JSON.parse(fs.readFileSync(configFilePath, "utf8")), "reactExtension");
+            if (fs.existsSync(path)) {
+              createFile(path, name, type, extension);
+            }
+            else {
+              console.log(chalk.red(`🦄 Directory not found! Creating the directory...`));
+              shelljs.mkdir('-p', path);
+              console.log(chalk.green(`🦄 Directory created! Adding the component...`))
+              createFile(path, name, type, extension);
+            }
           }
         }
         else {
-          fileExtension = 'ts';
-          console.log(`Found a tsconfig.json file.`)
-          if (fs.existsSync(path)) {
-            console.log(`🦄 Directory found! Adding the component...`)
-            createFile(path, name, type, extension);
+          if (!fs.existsSync(configFilePath)) {
+            extension = 'ts';
+            if (fs.existsSync(path)) {
+              createFile(path, name, type, extension);
+            }
+            else {
+              console.log(chalk.red(`🦄 Directory not found! Creating the directory...`));
+              shelljs.mkdir('-p', path);
+              console.log(chalk.green(`🦄 Directory created! Adding the component...`))
+              createFile(path, name, type, extension);
+            }
           }
           else {
-            console.log(chalk.red(`🦄 Directory not found! Creating the directory...`))
-            shelljs.mkdir('-p', path);
-            console.log(chalk.green(`🦄 Directory created! Adding the component...`))
-            createFile(path, name, type, extension);
+            extension = objectPath.get(JSON.parse(fs.readFileSync(configFilePath, "utf8")), "reactExtension");
+            if (fs.existsSync(path)) {
+              createFile(path, name, type, extension);
+            }
+            else {
+              console.log(chalk.red(`🦄 Directory not found! Creating the directory...`));
+              shelljs.mkdir('-p', path);
+              console.log(chalk.green(`🦄 Directory created! Adding the component...`))
+              createFile(path, name, type, extension);
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "figlet": "^1.5.2",
     "inquirer": "^8.2.1",
     "listr": "^0.14.3",
+    "object-path": "^0.11.8",
     "shelljs": "^0.8.5"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,11 @@ object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-path@^0.11.8:
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.8.tgz#ed002c02bbdd0070b78a27455e8ae01fc14d4742"
+  integrity sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"


### PR DESCRIPTION
Now nextrate supports react file extensions (`.jsx` and `.tsx`) :tada:

To use react file extensions with nextrate, run the `nextrate` command. If you don't have a `.nextrate` command in your current working directory, you would be presented with a new question that would ask whether you want to use the react file extensions format or the normal file extensions format for this project.

![image](https://user-images.githubusercontent.com/90365542/160279804-1354deb0-a9cd-49df-b0dd-63e7b2c83d25.png)
